### PR TITLE
Add Anki 2.1.50+ support and fix a couple bugs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -60,7 +60,7 @@ def generateFurigana(editor: Editor, s: Selection) -> None:
     html = re.sub('\[[^\]]*\]', '', html)
     html = mecab.reading(html, config.getIgnoreNumbers(), config.getUseRubyTags())
     if html == s.selected:
-        tooltip(_("Nothing to generate!"))
+        tooltip("Nothing to generate!")
     else:
         s.modify(html)
 
@@ -69,7 +69,7 @@ def deleteFurigana(editor: Editor, s: Selection) -> None:
     if config.getUseRubyTags():
         betweens = list(map(lambda x: "<ruby>"+x+"</ruby>", re.findall(r"<ruby>(.*?)<\/ruby>", html)))
         if len(betweens) == 0:
-            tooltip(_("No furigana found to delete"))
+            tooltip("No furigana found to delete")
         else:
             for b in betweens:
                 replacement = re.search(r"<ruby>(.*?)<rp>",b).group(1).strip()
@@ -79,7 +79,7 @@ def deleteFurigana(editor: Editor, s: Selection) -> None:
         html, deletions = re.subn('\[[^\]]*\]', '', html)
 
         if deletions == 0:
-            tooltip(_("No furigana found to delete"))
+            tooltip("No furigana found to delete")
         else:
             s.modify(html)
 

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ import os
 
 from aqt.utils import tooltip
 from aqt.qt import *
+from aqt.editor import Editor
 
 from aqt import mw
 
@@ -43,7 +44,7 @@ def setupGuiMenu():
     mw.form.menuTools.addAction(useRubyTags)
     mw.form.menuTools.addAction(ignoreNumbers)
 
-def addButtons(buttons, editor):
+def addButtons(buttons: list[str], editor: Editor) -> list[str]:
     editor._links["generateFurigana"] = lambda ed=editor: doIt(ed, generateFurigana)
     editor._links["deleteFurigana"] = lambda ed=editor: doIt(ed, deleteFurigana)
     return buttons + [
@@ -51,10 +52,10 @@ def addButtons(buttons, editor):
         editor._addButton(os.path.join(os.path.dirname(__file__), "icons", "del_furigana.svg"), "deleteFurigana", tip=u"Mass delete furigana")
     ]
 
-def doIt(editor, action):
+def doIt(editor: Editor, action: Callable[[Editor, Selection], None]):
     Selection(editor, lambda s: action(editor, s))
     
-def generateFurigana(editor, s):
+def generateFurigana(editor: Editor, s: Selection) -> None:
     html = s.selected
     html = re.sub('\[[^\]]*\]', '', html)
     html = mecab.reading(html, config.getIgnoreNumbers(), config.getUseRubyTags())
@@ -63,7 +64,7 @@ def generateFurigana(editor, s):
     else:
         s.modify(html)
 
-def deleteFurigana(editor, s):
+def deleteFurigana(editor: Editor, s: Selection) -> None:
     html = s.selected
     if config.getUseRubyTags():
         betweens = list(map(lambda x: "<ruby>"+x+"</ruby>", re.findall(r"<ruby>(.*?)<\/ruby>", html)))

--- a/reading.py
+++ b/reading.py
@@ -14,7 +14,7 @@ import os
 import re
 import subprocess
 
-from anki.utils import isWin, isMac
+from anki.utils import is_win, is_mac
 
 kakasiArgs = ["-isjis", "-osjis", "-u", "-JH", "-KH"]
 mecabArgs = ['--node-format=%m[%f[7]] ', '--eos-format=\n',
@@ -52,10 +52,10 @@ else:
 # Mecab
 
 def mungeForPlatform(popen):
-    if isWin:
+    if is_win:
         popen = [os.path.normpath(x) for x in popen]
         popen[0] += ".exe"
-    elif not isMac:
+    elif not is_mac:
         popen[0] += ".lin"
     return popen
 
@@ -69,7 +69,7 @@ class MecabController(object):
         self.mecabCmd = mungeForPlatform([os.path.join(mecabDir, "mecab")] + mecabArgs + ['-d', mecabDir, '-r', os.path.join(mecabDir, "mecabrc")])
         os.environ['DYLD_LIBRARY_PATH'] = mecabDir
         os.environ['LD_LIBRARY_PATH'] = mecabDir
-        if not isWin:
+        if not is_win:
             os.chmod(self.mecabCmd[0], 0o755)
 
     def ensureOpen(self):
@@ -168,7 +168,7 @@ class KakasiController(object):
         self.kakasiCmd = mungeForPlatform([os.path.join(mecabDir, "kakasi")] + kakasiArgs)
         os.environ['ITAIJIDICT'] = os.path.join(mecabDir, "itaijidict")
         os.environ['KANWADICT'] = os.path.join(mecabDir, "kanwadict")
-        if not isWin:
+        if not is_win:
             os.chmod(self.kakasiCmd[0], 0o755)
 
     def ensureOpen(self):

--- a/selection.py
+++ b/selection.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Japanese Furigana <https://github.com/obynio/anki-japanese-furigana>.
+#
+# Japanese Furigana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Japanese Furigana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Japanese Furigana.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import re
+
+from aqt.qt import *
+
+from anki.buildinfo import version
+
+class Selection:
+
+    js_get_html = u"""
+        var selection = window.getSelection();
+        var range = selection.getRangeAt(0);
+        var div = document.createElement('div');
+        div.appendChild(range.cloneContents());
+        div.innerHTML;
+    """
+
+    def __init__(self, window, callback):
+        self.window = window
+        self.setHtml(None, callback)
+
+    def isDeprecated(self):
+        return int(version.replace('.', '')) < 2141
+
+    def setHtml(self, elements, callback, allowEmpty=False):
+        self.selected = elements
+        if self.selected == None:
+            if self.isDeprecated():
+                self.window.web.eval("setFormat('selectAll');")
+                self.window.web.page().runJavaScript(self.js_get_html, lambda x: self.setHtml(x, callback, True))
+            else:
+                self.window.web.page().runJavaScript("getCurrentField().fieldHTML", lambda x: self.setHtml(x, callback, True))
+            return
+        self.selected = self.convertMalformedSpaces(self.selected)
+        callback(self)
+
+    def convertMalformedSpaces(self, text):
+        return re.sub(r'& ?nbsp ?;', ' ', text)
+
+    def modify(self, html):
+        html = self.convertMalformedSpaces(html)
+        if self.isDeprecated():
+            self.window.web.eval("setFormat('insertHTML', %s);" % json.dumps(html))
+        else:
+            self.window.web.page().runJavaScript("getCurrentField().fieldHTML = %s;" % json.dumps(html))


### PR DESCRIPTION
Hi!

Huge caveat that I'm not a Python developer, and this is my first time working with Anki, so please be welcome to suggest any changes, big or small!

[Anki 2.1.50](https://github.com/ankitects/anki/releases/tag/2.1.50) released further refactors to the editor interface, which broke this plugin (and many others like it). In particular, it appears that `getCurrentField` was removed from the runtime, which mean that trying to find the HTML for the current field was producing an infinite loop (the JS was erroring, and the callback was then called with `elements=None`, which would call the JS again).

I spent a long time trying to figure out what the new best solution was, but wasn't able to really get a good sense from looking through the Anki PRs what would directly replace the removal of `getCurrentField`. In lieu of that, I opted to use the `note` and `currentField` fields on the `Editor` object. However, these has been around for a couple of years now, so I'm not sure if there's a particular reason not to use them. Any tips here would be appreciated!

## Additional Changes
Additionally, I made a couple of changes as I was working. If you'd prefer I separate them into other PRs for better tracking/visibility, I'm happy to do so!

* Added (some) type hinting.
  * In order to support this without needing to mess with forward definitions of the `Selection` class, I opted to move `Selection` into its own file
* Addressed some deprecations that were showing up in the Anki output.
  * `isWin` and `isMac` were replaced by `is_win` and `is_mac`
  * The global `_(...)` function is deprecated by Anki and will be removed in a future version. Here too I spent some time trying to figure out how to migrate to their new system, but [per Anki's translation documentation for add-ons](https://translating.ankiweb.net/anki/developers.html#add-ons), it looks like they want us to roll our own rather than use the same system Anki uses
* Reworked the MeCab parser in order to fix issues with formatting furigana using `<ruby>` tags
  * Specifically, my cards will follow the format of me bolding the word in the sentence I'm quizzing myself on (example: 「目の前に**聳える**ビルへ歩を進めた。」). While the actual annotation of the readings worked fine alongside the `<b>` tags to produce the `聳える[そびえる]` style, it broke down when needing to convert from that style into `<ruby>`, meaning I was left with a mix of half-`<ruby>` and half-brackets.
  * For this, I decided to go back to the drawing board and move away from working directly into any particular format. Rather than producing an array of strings, we work in `ReadingNode` class objects, and at the end we join them together and format them into the appropriate string, so that there's no need to parse one style and convert to another.
