### PR TITLE
Exclude kana in between kanji from generating furigana

### DIFF
--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -1,50 +1,35 @@
-import sys
 import unittest
-from unittest.mock import MagicMock, patch
-
-sys.modules['anki'] = MagicMock()
-sys.modules['anki.utils'] = MagicMock()
 
 import reading
-import re
 
-# Just a mock to strip basic html
-def stripHTML(s: str) -> str:
-    cleanr = re.compile('<.*?>|&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});')
-    cleantext = re.sub(cleanr, '', s)
-    return cleantext
-
-@patch('reading.isWin', sys.platform.startswith("win32"))
-@patch('reading.isMac', sys.platform.startswith("darwin"))
-@patch('reading.stripHTML', side_effect=stripHTML)
 class TestReading(unittest.TestCase):
 
     # sentence should have readings
-    def testNormalSentence(self, mock_strip):
+    def testNormalSentence(self):
         res = reading.mecab.reading("カリン、自分でまいた種は自分で刈り取れ")
-        self.assertEqual(res, "カリン、 自分[じぶん]でまいた 種[たね]は 自分[じぶん]で 刈り取[かりと]れ")
+        self.assertEqual(res, "カリン、自分[じぶん]でまいた種[たね]は自分[じぶん]で刈り取[かりと]れ")
 
     # kanji should have a reading
-    def testNormalKanji(self, mock_strip):
+    def testNormalKanji(self):
         res = reading.mecab.reading("千葉")
         self.assertEqual(res, "千葉[ちば]")
 
     # punctuation should be ignored
-    def testWithPunctuation(self, mock_strip):
+    def testWithPunctuation(self):
         res = reading.mecab.reading("昨日、林檎を2個買った。")
-        self.assertEqual(res, "昨日[きのう]、 林檎[りんご]を2 個[こ] 買[か]った。")
+        self.assertEqual(res, "昨日[きのう]、林檎[りんご]を2個[こ]買[か]った。")
 
     # unicode characters should be ignored
-    def testUnicodeChar(self, mock_strip):
+    def testUnicodeChar(self):
         res = reading.mecab.reading("真莉、大好きだよん＾＾")
-        self.assertEqual(res, "真[ま]莉、 大好[だいす]きだよん＾＾")
+        self.assertEqual(res, "真[ま]莉、大好[だいす]きだよん＾＾")
 
     # romanji numbers should not have readings
-    def testRomanjiNumbers(self, mock_strip):
+    def testRomanjiNumbers(self):
         res = reading.mecab.reading("彼２０００万も使った。")
-        self.assertEqual(res, "彼[かれ]２０００ 万[まん]も 使[つか]った。")
+        self.assertEqual(res, "彼[かれ]２０００万[まん]も使[つか]った。")
 
     # kanji numbers should not have readings
-    def testKanjiNumber(self, mock_strip):
+    def testKanjiNumber(self):
         res = reading.mecab.reading("彼二千三百六十円も使った。")
-        self.assertEqual(res, "彼[かれ]二 千[せん]三 百[ひゃく]六十 円[えん]も 使[つか]った。")
+        self.assertEqual(res, "彼[かれ]二千[せん]三百[ひゃく]六十円[えん]も使[つか]った。")

--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -7,7 +7,7 @@ class TestReading(unittest.TestCase):
     # sentence should have readings
     def testNormalSentence(self):
         res = reading.mecab.reading("カリン、自分でまいた種は自分で刈り取れ")
-        self.assertEqual(res, "カリン、自分[じぶん]でまいた種[たね]は自分[じぶん]で刈り取[かりと]れ")
+        self.assertEqual(res, "カリン、自分[じぶん]でまいた種[たね]は自分[じぶん]で刈[か]り取[と]れ")
 
     # kanji should have a reading
     def testNormalKanji(self):
@@ -51,3 +51,10 @@ class TestReading(unittest.TestCase):
     def testKanaPrefixSuffix(self):
         actual = reading.mecab.reading("みじん切り")
         self.assertEqual(actual, "みじん切[ぎ]り")
+
+    # ensure that for words that have kana in between two kanji, that only the
+    # kanji receive furigana readings and the kana does not
+    def testKanaBetweenKanji(self):
+        self.assertEqual(reading.mecab.reading("書き込む"), "書[か]き込[こ]む")
+        self.assertEqual(reading.mecab.reading("走り抜く"), "走[はし]り抜[ぬ]く")
+        self.assertEqual(reading.mecab.reading("走り回る"), "走[はし]り回[まわ]る")

--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -33,3 +33,21 @@ class TestReading(unittest.TestCase):
     def testKanjiNumber(self):
         res = reading.mecab.reading("彼二千三百六十円も使った。")
         self.assertEqual(res, "彼[かれ]二千[せん]三百[ひゃく]六十円[えん]も使[つか]った。")
+
+    # ensure that verbs with okurigana don't produce furigana for the kana portions
+    def testOkurigana(self):
+        actual = reading.mecab.reading("口走る")
+        self.assertEqual(actual, "口走[くちばし]る")
+    
+    # ensure that a single word that has plain kana appearing before the kanji in
+    # the word do not have attached furigana
+    def testKanaPrefixes(self):
+        actual = reading.mecab.reading("お前")
+        self.assertEqual(actual, "お前[まえ]")
+
+    # ensure that a single word that both begins AND ends with kana but contains
+    # kanji in the middle only generates furigana for the kanji portion, and not
+    # for the kana
+    def testKanaPrefixSuffix(self):
+        actual = reading.mecab.reading("みじん切り")
+        self.assertEqual(actual, "みじん切[ぎ]り")


### PR DESCRIPTION
This closes #12.

The response from Mecab for a word looks like `食べる[タベル]`. The current implementation has support for hiragana/katakana at the starts and ends of the word, and will not include these in the furigana output (eg: `食べる[タベル]`→ `食[た]べる`. However, for a word that has hiragana between two kanji (eg 走り出す), the kana in between the kanji would be included in the furigana.

**Expected:** 走[はし]り出[だ]す
**Actual:** 走り出[はしりだ]す

This PR reworks the algorithm that was handling words with kanji support, away from an implementation that had custom logic for the starts and ends of words, and into one that operates on a general string matching algorithm. Going character by character through both the reading and the kanji, it matches hiragana substrings together into `ReadingNode`s with no reading, and uses lazy string matching to find the shortest reading for the kanji before we encounter another kana match between reading and kanji.

In order to ensure there were no regressions, I fixed up the unit tests (which had some existing breaks) and added new ones that supported all previous cases as well as new ones that specifically target this use case.

I've tested this on both Anki 2.1.54 (M1 Silicon) and Anki 2.1.49 (Intel), and it loads and appears to work fine. I ran a large number of cards through this algorithm and found no outliers for this algorithm.