### PR TITLE
Retain ASCII space characters in original input string

### DIFF
--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -58,3 +58,9 @@ class TestReading(unittest.TestCase):
         self.assertEqual(reading.mecab.reading("書き込む"), "書[か]き込[こ]む")
         self.assertEqual(reading.mecab.reading("走り抜く"), "走[はし]り抜[ぬ]く")
         self.assertEqual(reading.mecab.reading("走り回る"), "走[はし]り回[まわ]る")
+
+    # ensure that any regular ASCII space characters (0x20) that are in the original
+    # string are found in the resultant string as well
+    def testSpacesRetained(self):
+        self.assertEqual(reading.mecab.reading("この文に 空白が あります"), "この文[ぶん]に 空白[くうはく]が あります")
+        self.assertEqual(reading.mecab.reading("hello world"), "hello world")


### PR DESCRIPTION
The response from MeCab is space-delineated, where individual kanji/reading nodes are separated with an ASCII space (eg, `リンゴ[リンゴ] を[ヲ] 食べる[タベル]`). When we process the result, we work on a single MeCab node at a time to determine when we actually need a reading/need furigana or not. To do this, we split the string on ASCII spaces. But this means that any input string that does have an ASCII space in it has them stripped from the final result, as MeCab doesn't distinguish spaces that were in the original string from ones that are being added to delineate nodes.

In order to fix this, I modified the code to replace all ASCII spaces (0x20 codepoint) with a Unicode character that we should never encounter in any card in the wild. At the end, we then reverse the replacement. This is the same approach as is handled for newlines.

I've tested this on both Anki 2.1.54 (M1 Silicon) and Anki 2.1.49 (Mac Intel) and have run into no issues.