### PR TITLE
Remove <ruby> furigana before generating readings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Japanese Furigana.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
 import os
 
 from aqt.utils import tooltip
@@ -58,7 +57,7 @@ def doIt(editor, action):
     
 def generateFurigana(editor, s):
     html = s.selected
-    html = re.sub('\[[^\]]*\]', '', html)
+    html = removeFurigana(html)
     html = mecab.reading(html, config.getIgnoreNumbers(), config.getUseRubyTags())
     if html == s.selected:
         tooltip("Nothing to generate!")

--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,7 @@ from anki.hooks import addHook
 from . import reading
 from . import config
 from .selection import Selection
+from .utils import removeFurigana
 
 mecab  = reading.MecabController()
 config = config.Config()
@@ -65,23 +66,11 @@ def generateFurigana(editor, s):
         s.modify(html)
 
 def deleteFurigana(editor, s):
-    html = s.selected
-    if config.getUseRubyTags():
-        betweens = list(map(lambda x: "<ruby>"+x+"</ruby>", re.findall(r"<ruby>(.*?)<\/ruby>", html)))
-        if len(betweens) == 0:
-            tooltip("No furigana found to delete")
-        else:
-            for b in betweens:
-                replacement = re.search(r"<ruby>(.*?)<rp>",b).group(1).strip()
-                html = html.replace(b, replacement)
-            s.modify(html)
+    stripped = removeFurigana(s.selected)
+    if stripped == s.selected:
+        tooltip("No furigana found to delete")
     else:
-        html, deletions = re.subn('\[[^\]]*\]', '', html)
-
-        if deletions == 0:
-            tooltip("No furigana found to delete")
-        else:
-            s.modify(html)
+        s.modify(stripped)
 
 setupGuiMenu()
 addHook("setupEditorButtons", addButtons)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,3 +17,8 @@ class TestRemoveFurigana(unittest.TestCase):
     def testRemovesRuby(self):
         self.assertEqual(utils.removeFurigana("<ruby>日本語<rp>(</rp><rt>にほんご</rt><rp>)</rp></ruby>を<ruby>勉強<rp>(</rp><rt>べんきょう</rt><rp>)</rp></ruby>する"), "日本語を勉強する")
         self.assertEqual(utils.removeFurigana("<ruby>走<rp>(</rp><rt>はし</rt><rp>)</rp></ruby>り<ruby>込<rp>(</rp><rt>こ</rt><rp>)</rp></ruby>む"), "走り込む")
+
+    # ensure that <ruby /> tags without the inessential <rp /> tags are stripped
+    def testRemovesRubyWithoutRp(self):
+        self.assertEqual(utils.removeFurigana("<ruby>日本語<rt>にほんご</rt></ruby>を<ruby>勉強<rt>べんきょう</rt></ruby>する"), "日本語を勉強する")
+        self.assertEqual(utils.removeFurigana("<ruby>走<rt>はし</rt></ruby>り<ruby>込<rt>こ</rt></ruby>む"), "走り込む")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -27,3 +27,8 @@ class TestRemoveFurigana(unittest.TestCase):
     def testPreservesOtherHtml(self):
         self.assertEqual(utils.removeFurigana("<b>日本語</b>"), "<b>日本語</b>")
         self.assertEqual(utils.removeFurigana("ビルの<ruby>形<rp>(</rp><rt>かたち</rt><rp>)</rp></ruby>はほぼ<b><u><ruby>正方形<rp>(</rp><rt>せいほうけい</rt><rp>)</rp></ruby></u></b>だった。"), "ビルの形はほぼ<b><u>正方形</u></b>だった。")
+
+    # ensure that the utility function will remove both styles from the same string
+    # (which also ensures that we're decoupled from the user's current config selection)
+    def testRemovesBothNotations(self):
+        self.assertEqual(utils.removeFurigana("<ruby>日本語<rp>(</rp><rt>にほんご</rt><rp>)</rp></ruby>を勉強[べんきょう]する"), "日本語を勉強する")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -22,3 +22,8 @@ class TestRemoveFurigana(unittest.TestCase):
     def testRemovesRubyWithoutRp(self):
         self.assertEqual(utils.removeFurigana("<ruby>日本語<rt>にほんご</rt></ruby>を<ruby>勉強<rt>べんきょう</rt></ruby>する"), "日本語を勉強する")
         self.assertEqual(utils.removeFurigana("<ruby>走<rt>はし</rt></ruby>り<ruby>込<rt>こ</rt></ruby>む"), "走り込む")
+
+    # ensure that non-<ruby> related HTML tags are preserved
+    def testPreservesOtherHtml(self):
+        self.assertEqual(utils.removeFurigana("<b>日本語</b>"), "<b>日本語</b>")
+        self.assertEqual(utils.removeFurigana("ビルの<ruby>形<rp>(</rp><rt>かたち</rt><rp>)</rp></ruby>はほぼ<b><u><ruby>正方形<rp>(</rp><rt>せいほうけい</rt><rp>)</rp></ruby></u></b>だった。"), "ビルの形はほぼ<b><u>正方形</u></b>だった。")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,19 @@
+import unittest
+
+import utils
+
+class TestRemoveFurigana(unittest.TestCase):
+
+    # empty string should return empty string
+    def testEmptyString(self):
+        self.assertEqual(utils.removeFurigana(""), "")
+
+    # ensure that bracket notation is correctly removed
+    def testRemovesBrackets(self):
+        self.assertEqual(utils.removeFurigana("日本語[にほんご]を勉強[べんきょう]する"), "日本語を勉強する")
+        self.assertEqual(utils.removeFurigana("走[はし]り込[こ]む"), "走り込む")
+
+    # ensure that ruby tags are correctly removed
+    def testRemovesRuby(self):
+        self.assertEqual(utils.removeFurigana("<ruby>日本語<rp>(</rp><rt>にほんご</rt><rp>)</rp></ruby>を<ruby>勉強<rp>(</rp><rt>べんきょう</rt><rp>)</rp></ruby>する"), "日本語を勉強する")
+        self.assertEqual(utils.removeFurigana("<ruby>走<rp>(</rp><rt>はし</rt><rp>)</rp></ruby>り<ruby>込<rp>(</rp><rt>こ</rt><rp>)</rp></ruby>む"), "走り込む")

--- a/utils.py
+++ b/utils.py
@@ -6,11 +6,18 @@ def removeFurigana(text: str):
     stripped = text
 
     # First, remove Ruby tags
-    betweens = list(map(lambda x: "<ruby>"+x+"</ruby>", re.findall(r"<ruby>(.*?)<\/ruby>", stripped)))
-    if len(betweens) > 0:
-        for b in betweens:
-            replacement = re.search(r"<ruby>(.*?)<rp>",b).group(1).strip()
-            stripped = stripped.replace(b, replacement)
+    rubyTags: list[str] = re.findall(r"<ruby>(.*?)<\/ruby>", stripped)
+    for ruby in rubyTags:
+        # Figure out what the actual body of the <ruby /> tag is.
+        # Current approach: strip away any HTML tags that handle the annotation, to
+        # arrive at just the body. Considering only the current HTML specification,
+        # the tags to strip away are: <rp>, <rt>
+        body = re.sub(r"<rp>(.*?)<\/rp>|<rt>(.*?)<\/rt>", "", ruby)
+
+        # Replace the entire <ruby> block with just the body.
+        # NOTE: We'll need to include the <ruby> tags around the search string, since
+        # they aren't included in the original regex response
+        stripped = stripped.replace("<ruby>" + ruby + "</ruby>", body)
 
     # Next, remove the bracket notation
     stripped, _ = re.subn('\[[^\]]*\]', '', stripped)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import re
+
+def removeFurigana(text: str):
+    stripped = text
+
+    # First, remove Ruby tags
+    betweens = list(map(lambda x: "<ruby>"+x+"</ruby>", re.findall(r"<ruby>(.*?)<\/ruby>", stripped)))
+    if len(betweens) > 0:
+        for b in betweens:
+            replacement = re.search(r"<ruby>(.*?)<rp>",b).group(1).strip()
+            stripped = stripped.replace(b, replacement)
+
+    # Next, remove the bracket notation
+    stripped, _ = re.subn('\[[^\]]*\]', '', stripped)
+
+    # Return the final string
+    return stripped


### PR DESCRIPTION
Before we run the current field through `mecab.reading` to attach furigana, [line 60](https://github.com/obynio/anki-japanese-furigana/blob/6213c227cf74023ebe9a7c20cb35a7be6a9d7743/__init__.py#L60) correctly removes the bracket notation furigana already in the input string. This prevents clicking the button multiple times from compounding the readings. However, `<ruby>` markup is not removed before sending for generation, which compounds additional readings:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/1350141/194390594-2e5c40f7-90c1-4f17-ae4a-e3704d5482e0.png">

To fix this, I extracted the code from the "delete furigana" button into a reusable utility function `removeFurigana`. We then use this to remove readings before sending the text through generation.

In doing this, I fixed a couple of bugs with the furigana deletion logic:
* **Decoupled from current config.** Every string is run through both `<ruby>` removal _and_ bracket notation removal. Use cases:
  * User has changed their config setting and would like to generate in the new style
  * User used another plugin to generate the original content (in bracket notation) and wants to use this tool to replace it with new style (`<ruby>`)
* **Removes reliance on `<rp>` tag.** The original implementation required a format of `<ruby>日本語<rp>...` in order to work. If you didn't include the `<rp>` tag (which is optional in the HTML specification), it would throw errors. It worked in the general flow because this tool always included the `<rp>` tag. I've reimplemented this to decouple from a particular structure and to just remove `<rp>` and `<rt>` tags to arrive at the body instead.

I've added some unit tests to test these behaviors.

I've tested this in both 2.1.54 (M1 Silicon) and 2.1.49 (Mac Intel) and it loads and works as expected.