### PR TITLE
Rework kanji/reading association using RegEx to address 息抜き bug

### DIFF
--- a/reading.py
+++ b/reading.py
@@ -100,12 +100,18 @@ translator = Translator()
 def convertToHiragana(expr: str) -> str:
     return expr.translate(translator)
 
-# Determines if two strings have the same phonetic reading, regardless
-# of which script they're currently in (eg, 'は' == 'は' and 'ハ' == 'は')
-def areKanaEqual(a: str, b: str) -> bool:
-    hiraA = convertToHiragana(a)
-    hiraB = convertToHiragana(b)
-    return hiraA == hiraB
+def isKana(char: str) -> bool:
+    code = ord(char)
+
+    # Hiragana
+    if code >= UNICODE_HIRAGANA_START and code <= UNICODE_HIRAGANA_END:
+        return True
+
+    # Katakana
+    if code >= UNICODE_KATAKANA_START and code <= UNICODE_KATAKANA_END:
+        return True
+
+    return False
 
 # Mecab
 
@@ -132,6 +138,44 @@ class ReadingNode:
             return "<ruby>%s<rp>(</rp><rt>%s</rt><rp>)</rp></ruby>" % (self.text, self.reading)
         else:
             return '%s[%s]' % (self.text, self.reading)
+
+class RegexDefinition:
+    def __init__(self, text: str, regexGroupIndex: Optional[int]):
+        self.text = text
+        self.regexGroupIndex = regexGroupIndex
+
+def kanjiToRegex(kanji: str):
+    regexPieces: list[str] = []
+    definitions: list[RegexDefinition] = []
+    numCaptureGroups = 0
+    index = 0
+    while index < len(kanji):
+        # Hiragana and Katakana characters are inlined into the Regex
+        if isKana(kanji[index]):
+            # The reading variable is ALWAYS in hiragana only
+            regexPieces.append(convertToHiragana(kanji[index]))
+
+            # Use kanji[index] here to retain original katakana/hiragana
+            # (We convert to hiragana just to match against reading)
+            definitions.append(RegexDefinition(kanji[index], None))
+
+            # Advance to the next character
+            index += 1
+            continue
+
+        # We have a kanji character, which will become a lazy capture group
+        # in our Regex. First, absorb all sequential kanji characters into a
+        # single capture group
+        captureGroup = ""
+        while index < len(kanji) and not isKana(kanji[index]):
+            captureGroup += kanji[index]
+            index += 1
+
+        regexPieces.append("(.+?)")
+        definitions.append(RegexDefinition(captureGroup, numCaptureGroups))
+        numCaptureGroups += 1
+
+    return ("^%s$" % ''.join(regexPieces), definitions)
 
 class MecabController(object):
 
@@ -188,49 +232,18 @@ class MecabController(object):
                 nodes.append(ReadingNode(kanji, None))
                 continue
 
-            # iterate through the reading and the kanji, and only produce furigana
-            # for the characters that differ between the two (only give furigana to
-            # the kanji, not the kana)
-            # INVARIANT: reading is always at least as long as the kanji/word
-            indexKanji = 0
-            indexReading = 0
-            while indexReading < len(reading):
-                # If the reading and the kanji have the same value, the current
-                # character must be kana. Continue reading until we find the next
-                # difference
-                if areKanaEqual(kanji[indexKanji], reading[indexReading]):
-                    indexStart = indexKanji
-                    while indexReading < len(reading) and \
-                        indexKanji < len(kanji) and \
-                            areKanaEqual(kanji[indexKanji], reading[indexReading]):
-                        indexReading += 1
-                        indexKanji += 1
-                    nodes.append(ReadingNode(kanji[indexStart:indexKanji], None))
-                    continue
-
-                # The current characters are different, which must mean that we're
-                # at the start of a kanji. Make a node with furigana that contains
-                # all of the reading until we have a match up again between kanji string
-                # and reading
-                indexStartReading = indexReading
-                indexReading += 1 # Ensure we start our checks on the NEXT kana after triggering
-                while indexReading < len(reading):
-                    # Check to see if the current reading kana is found in the string.
-                    # This implements a lazy algorithm w.r.t. furigana length
-                    try:
-                        indexEnd = kanji.index(reading[indexReading], indexKanji)
-                        nodes.append(ReadingNode(kanji[indexKanji:indexEnd], reading[indexStartReading:indexReading]))
-                        indexKanji = indexEnd
-                        break
-                    except ValueError:
-                        pass
-                    
-                    indexReading += 1
-
-                if indexReading == len(reading):
-                    # We made it to the end of the reading, which should mean that the entire remaining
-                    # kanji has the entire remaining reading
-                    nodes.append(ReadingNode(kanji[indexKanji:], reading[indexStartReading:]))
+            # Convert the kanji variable into a Regex pattern where non-kana are
+            # turned into Regex capture groups, and then apply it to the reading
+            # to figure out (using lazy matching) what the smallest furigana readings
+            # are for the kanji
+            (regexPattern, regexDefinitions) = kanjiToRegex(kanji)
+            match = re.search(regexPattern, reading)
+            for definition in regexDefinitions:
+                if definition.regexGroupIndex is None:
+                    nodes.append(ReadingNode(definition.text, None))
+                else:
+                    groupReading = match.group(definition.regexGroupIndex + 1)
+                    nodes.append(ReadingNode(definition.text, groupReading))
 
         # Combine our nodes together into a single sentece
         fin = ''.join(node.format(useRubyTags) for node in nodes)

--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -41,8 +41,8 @@ class TestMecab(unittest.TestCase):
 
     # ensure that verbs with okurigana don't produce furigana for the kana portions
     def testOkurigana(self):
-        actual = reading.mecab.reading("口走る")
-        self.assertEqual(actual, "口走[くちばし]る")
+        self.assertEqual(reading.mecab.reading("口走る"), "口走[くちばし]る")
+        self.assertEqual(reading.mecab.reading("テスト勉強の息抜きとか　どうしてんの"), "テスト勉強[べんきょう]の息抜[いきぬ]きとか　どうしてんの")
     
     # ensure that a single word that has plain kana appearing before the kanji in
     # the word do not have attached furigana


### PR DESCRIPTION
This will close #23.

There was a bug with generating readings for 息抜き under the current kanji/reading association algorithm. This is because the reading is `いきぬき`, and when it goes character by character and arrives at the first き, it uses `kanji.index` and detects the き at the end of the string and skips ahead to there, believing that `息抜` together receives the reading of `い`. It then runs out of characters in the kanji and crashes.

For this PR, I've rewritten the association code using regular expressions. What was important was to have an algorithm that had a full view of the entire string — one that would realize there's a second き in the reading.

The idea here is that we take the `kanji` (息抜き) and convert this into a regular expression. We want the plugin to only generate furigana for kanji and not kana, so this regular expression helps us detect what "holes" should have furigana and which ones should.

`kanji` (息抜き) becomes → `^(.+?)き$`

We then apply this regular expression to the `reading` (いきぬき), which results a groups match of `[ "いきぬ" ]`. We then use the Kanji to piece it all back together in the original order, reading from the regular expression match whenever we're replacing a `(.+?)`.

I've added the example sentence from the bug report as a unit test, and ensured that all existing unit tests continue to pass. I've also run it through more cards in my personal deck and found no issues with this algorithm yet.

I've tested in both Anki 2.1.54 and Anki 2.1.49.