### PR TITLE
Add support for small ヵ/ヶ being read as large か in words

### DIFF
--- a/test/test_reading.py
+++ b/test/test_reading.py
@@ -88,6 +88,28 @@ class TestMecab(unittest.TestCase):
         self.assertEqual(reading.mecab.reading("この文に 空白が あります"), "この文[ぶん]に 空白[くうはく]が あります")
         self.assertEqual(reading.mecab.reading("hello world"), "hello world")
 
+    # some kana characters will have different readings when used in readings
+    # (such as ヶ月 being read as かげつ). ensure that we can detect and handle these
+    def testKanaWithAdditionalReadings(self):
+        # Check that ヵ (small) stands in for か (large) in readings
+        # This should generate furigana for the small ヵ
+        self.assertEqual(reading.mecab.reading("彼はトルコを2ヵ月間訪問するつもりです"), "彼[かれ]はトルコを2ヵ[か]月[げつ]間[かん]訪問[ほうもん]するつもりです")
+
+        # Check that ヶ *also* stands in for か in readings
+        # This should generate furigana for the small ヶ
+        self.assertEqual(reading.mecab.reading("彼はトルコを2ヶ月間訪問するつもりです"), "彼[かれ]はトルコを2ヶ[か]月[げつ]間[かん]訪問[ほうもん]するつもりです")
+
+        # For the same sentence, also make sure that the full-sized か and カ
+        # are also recognized.
+        # However, neither of these should generate furigana.
+        self.assertEqual(reading.mecab.reading("彼はトルコを2か月間訪問するつもりです"), "彼[かれ]はトルコを2か月[げつ]間[かん]訪問[ほうもん]するつもりです")
+        self.assertEqual(reading.mecab.reading("彼はトルコを2カ月間訪問するつもりです"), "彼[かれ]はトルコを2カ月[げつ]間[かん]訪問[ほうもん]するつもりです")
+
+        # Finally, ensure that we're not just ALWAYS adding furigana to ヶ and ヵ
+        # whenever we encounter them
+        self.assertEqual(reading.mecab.reading("ィヵ"), "ィヵ")
+        self.assertEqual(reading.mecab.reading("ゥヶ"), "ゥヶ")
+
 class TestConvertToHiragana(unittest.TestCase):
     # ensure that if the function is called with an empty string, it will return
     # an empty string


### PR DESCRIPTION
This closes #27.

Currently, if you try to generate furigana on a word like 一ヵ月 or 二ヶ国, the plugin will throw an exception about not being able to match the Regex group. The reason for this is that the readings for both of these words have "か” (full sized) in the space where the text has ヵ or ヶ (small). Even after we convert these to hiragana (ゕ and ゖ), they don't match against the full-size character. When we're processing these two characters specifically, we need to also register that they should match both their own hiragana characters (ゕ and ゖ) but they should _also_ match full-sized か.

In this PR, I rework some of the `kanjiToRegex` function for when we're processing a regular kana character. If the single hiragana/katakana character we're looking at has additional possible readings _beyond_ just their own reading, then instead of producing a string literal within the Regex, we'll now produce a Regex capture group.
* Given `kanjiToRegex("ヶ月")`:
    * **Before:** `^ゖ(.+?)$`
    * **After:** `^(ゖ|か)(.+?)$`
    * In both situations, these regular expressions are then being matched against `reading = "かげつ"` (via MeCab)

If we don't have additional readings, we'll continue to go down the regular pathway, where we just output the hiragana directly.
* Given `kanjiToRegex("ローマ字")`:
    * **Before:** `^ろーま(.+?)$`
    * **After:** `^ろーま(.+?)$` (no change)

In the case where we have ヵ and ヶ, I've chosen to include furigana readings for them. I did this because Jisho includes readings in this situation, and because it's a situation where one character is being read as a different character — this can easily mess up beginner learners of Japanese, as it's very non-standard.

I've added unit tests to track all of this and prevent regressions.

I've tested this change in both Anki ⁨2.1.54 and Anki 2.1.49 (the version prior to the Python 2.10 bump).