### PR TITLE
Mass generation support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -96,6 +96,10 @@ def onBulkUpdate(browser):
     bulkUpdate(browser, nids)
 
 def bulkUpdate(browser, nids):
+    config = mw.addonManager.getConfig(__name__)
+    lastSourceField = config.get('lastSourceField', None)
+    lastDestinationField = config.get('lastDestinationField', None)
+
     # Extract fields from the first note
     note = mw.col.get_note(nids[0])
     fields = note.keys()
@@ -125,6 +129,12 @@ def bulkUpdate(browser, nids):
         sourceField.addItem(field)
         destinationField.addItem(field)
 
+        if field == lastSourceField:
+            sourceField.setCurrentText(field)
+
+        if field == lastDestinationField:
+            destinationField.setCurrentText(field)
+
     buttonsLayout = QHBoxLayout()
     layout.addLayout(buttonsLayout)
     generateButton = QPushButton('Generate', parent=dialog)
@@ -138,6 +148,13 @@ def bulkUpdate(browser, nids):
         sourceField = sourceField.currentText()
         destinationField = destinationField.currentText()
 
+        # Save the values to be remembered later
+        configs = {
+            'lastSourceField': sourceField,
+            'lastDestinationField': destinationField,
+        }
+        mw.addonManager.writeConfig(__name__, configs)
+
         def progressCallback(i, total):
             mw.taskman.run_on_main(
                 lambda: mw.progress.update(
@@ -150,7 +167,7 @@ def bulkUpdate(browser, nids):
         QueryOp(
             parent=mw,
             op=lambda col: bulkGenerate(col, nids, sourceField, destinationField, progressCallback),
-            success=lambda col: tooltip('Furigana generated successfully')
+            success=lambda col: tooltip('Furigana generated successfully'),
         ).with_progress().run_in_background()
 
 def doIt(editor, action):

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@
 import os
 
 from aqt.utils import tooltip
-from aqt.operations import CollectionOp
+from aqt.operations import QueryOp
 from aqt.qt import *
 
 from aqt import mw
@@ -147,10 +147,11 @@ def bulkUpdate(browser, nids):
                 )
             )
 
-        CollectionOp(
+        QueryOp(
             parent=mw,
             op=lambda col: bulkGenerate(col, nids, sourceField, destinationField, progressCallback),
-        ).run_in_background()
+            success=lambda col: tooltip('Furigana generated successfully')
+        ).with_progress().run_in_background()
 
 def doIt(editor, action):
     Selection(editor, lambda s: action(editor, s))

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@
 import os
 
 from aqt.utils import tooltip
-from aqt.operations import QueryOp
+from aqt.operations import CollectionOp
 from aqt.qt import *
 
 from aqt import mw
@@ -138,11 +138,19 @@ def bulkUpdate(browser, nids):
         sourceField = sourceField.currentText()
         destinationField = destinationField.currentText()
 
-        QueryOp(
+        def progressCallback(i, total):
+            mw.taskman.run_on_main(
+                lambda: mw.progress.update(
+                    label=f"{i}/{total}",
+                    value=i,
+                    max=total,
+                )
+            )
+
+        CollectionOp(
             parent=mw,
-            op=lambda col: bulkGenerate(col, nids, sourceField, destinationField),
-            success=lambda result: tooltip('Furigana generated successfully')
-        ).with_progress().run_in_background()
+            op=lambda col: bulkGenerate(col, nids, sourceField, destinationField, progressCallback),
+        ).run_in_background()
 
 def doIt(editor, action):
     Selection(editor, lambda s: action(editor, s))

--- a/bulk.py
+++ b/bulk.py
@@ -15,21 +15,31 @@
 # You should have received a copy of the GNU General Public License
 # along with Japanese Furigana.  If not, see <http://www.gnu.org/licenses/>.
 
+import time
+
 from . import reading
 from .config import Config
 from .utils import removeFurigana
+from aqt import *
 
 mecab = reading.MecabController()
 config = Config()
 
-def bulkGenerate(collection, noteIds, sourceField, destinationField):
+def bulkGenerate(collection, noteIds, sourceField, destinationField, progress):
     undo_entry = collection.add_custom_undo_entry('Batch Generate Furigana')
+    last_progress = 0
+    i = 0
 
     for noteId in noteIds:
         note = collection.get_note(noteId)
         note[destinationField] = generateFurigana(note[sourceField])
         collection.update_note(note)
         collection.merge_undo_entries(undo_entry)
+        i += 1
+
+        if time.time() - last_progress >= 0.1:
+            progress(i, len(noteIds))
+            last_progress = time.time()
 
 def generateFurigana(html):
     html = removeFurigana(html)

--- a/bulk.py
+++ b/bulk.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Japanese Furigana <https://github.com/obynio/anki-japanese-furigana>.
+#
+# Japanese Furigana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Japanese Furigana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Japanese Furigana.  If not, see <http://www.gnu.org/licenses/>.
+
+from . import reading
+from .config import Config
+from .utils import removeFurigana
+
+mecab = reading.MecabController()
+config = Config()
+
+def bulkGenerate(collection, noteIds, sourceField, destinationField):
+    undo_entry = collection.add_custom_undo_entry('Batch Generate Furigana')
+
+    for noteId in noteIds:
+        note = collection.get_note(noteId)
+        note[destinationField] = generateFurigana(note[sourceField])
+        collection.update_note(note)
+        collection.merge_undo_entries(undo_entry)
+
+def generateFurigana(html):
+    html = removeFurigana(html)
+    html = mecab.reading(html, config.getIgnoreNumbers(), config.getUseRubyTags())
+    return html


### PR DESCRIPTION
Hello, this is a very useful addon! I also found the need to generate Furigana in bulk, particularly for when I create Subs2SRS cards, so I've implemented it. This should close the long-standing enhancement request #7. I've implemented it as a QueryOp so it doesn't block the main thread, but I don't think there's any getting around the CPU usage. In my case, I don't really notice any significant PC slowdowns or anything, though. This PR adds this menu item:

<img width="337" alt="image" src="https://github.com/user-attachments/assets/3ed02d44-3acb-4685-aafd-4d83e0e47d06">

Which in turn opens this form where you can select what field to take from, and what field to save it in:

<img width="360" alt="image" src="https://github.com/user-attachments/assets/acc098b4-c7c6-441a-9447-20b439ea2ff7">