### PR TITLE
Refresh browser after bulk furigana generation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@
 import os
 
 from aqt.utils import tooltip
-from aqt.operations import QueryOp
+from aqt.operations import CollectionOp
 from aqt.qt import *
 
 from aqt import mw
@@ -144,7 +144,7 @@ def bulkUpdate(browser, nids):
     dialog.resize(320, 150)
 
     if dialog.exec():
-        # Get the values *before* QueryOp otherwise the QT objects will be disposed of
+        # Get the values *before* CollectionOp otherwise the QT objects will be disposed of
         sourceField = sourceField.currentText()
         destinationField = destinationField.currentText()
 
@@ -164,11 +164,10 @@ def bulkUpdate(browser, nids):
                 )
             )
 
-        QueryOp(
+        CollectionOp(
             parent=mw,
             op=lambda col: bulkGenerate(col, nids, sourceField, destinationField, progressCallback),
-            success=lambda col: tooltip('Furigana generated successfully'),
-        ).with_progress().run_in_background()
+        ).success(lambda _: tooltip('Furigana generated successfully')).run_in_background()
 
 def doIt(editor, action):
     Selection(editor, lambda s: action(editor, s))

--- a/bulk.py
+++ b/bulk.py
@@ -29,17 +29,20 @@ def bulkGenerate(collection, noteIds, sourceField, destinationField, progress):
     undo_entry = collection.add_custom_undo_entry('Batch Generate Furigana')
     last_progress = 0
     i = 0
+    changes = None
 
     for noteId in noteIds:
         note = collection.get_note(noteId)
         note[destinationField] = generateFurigana(note[sourceField])
         collection.update_note(note)
-        collection.merge_undo_entries(undo_entry)
+        changes = collection.merge_undo_entries(undo_entry)
         i += 1
 
         if time.time() - last_progress >= 0.1:
             progress(i, len(noteIds))
             last_progress = time.time()
+
+    return changes
 
 def generateFurigana(html):
     html = removeFurigana(html)


### PR DESCRIPTION
Bulk furigana generation mutates notes, but it was run via QueryOp so Anki did not receive operation change metadata to refresh the visible browser editor.

This switches the action to CollectionOp and returns the merged OpChanges from the bulk update.